### PR TITLE
Add tests for Keycloak no downtime upgrades usecases into index-evolution

### DIFF
--- a/index-evolution/pom.xml
+++ b/index-evolution/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <version.infinispan>13.0.5.Final</version.infinispan>
+        <version.infinispan>14.0.0.Dev03</version.infinispan>
         <version.junit>5.8.2</version.junit>
         <version.assertj>3.22.0</version.assertj>
         <version.surefire-plugin>2.22.2</version.surefire-plugin>
@@ -25,6 +25,10 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-client-hotrod</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-api</artifactId>
         </dependency>
 
         <dependency>

--- a/index-evolution/src/main/java/fax/play/model3/Model3A.java
+++ b/index-evolution/src/main/java/fax/play/model3/Model3A.java
@@ -1,0 +1,26 @@
+package fax.play.model3;
+
+import fax.play.service.Model;
+import org.infinispan.protostream.annotations.ProtoDoc;
+import org.infinispan.protostream.annotations.ProtoField;
+import org.infinispan.protostream.annotations.ProtoName;
+
+@ProtoDoc("@Indexed")
+@ProtoName("Model3")
+public class Model3A implements Model {
+
+    @ProtoField(number = 1)
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    public Integer entityVersion;
+
+    @ProtoField(number = 2)
+    public String id;
+
+    @ProtoField(number = 3)
+    public String name;
+
+    @Override
+    public String getId() {
+        return id;
+    }
+}

--- a/index-evolution/src/main/java/fax/play/model3/Model3B.java
+++ b/index-evolution/src/main/java/fax/play/model3/Model3B.java
@@ -1,0 +1,27 @@
+package fax.play.model3;
+
+import fax.play.service.Model;
+import org.infinispan.protostream.annotations.ProtoDoc;
+import org.infinispan.protostream.annotations.ProtoField;
+import org.infinispan.protostream.annotations.ProtoName;
+
+@ProtoDoc("@Indexed")
+@ProtoName("Model3")
+public class Model3B implements Model {
+
+    @ProtoField(number = 1)
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    public Integer entityVersion;
+
+    @ProtoField(number = 2)
+    public String id;
+
+    @ProtoField(number = 3)
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    public String name;
+
+    @Override
+    public String getId() {
+        return id;
+    }
+}

--- a/index-evolution/src/main/java/fax/play/model3/Model3C.java
+++ b/index-evolution/src/main/java/fax/play/model3/Model3C.java
@@ -1,0 +1,27 @@
+package fax.play.model3;
+
+import fax.play.service.Model;
+import org.infinispan.protostream.annotations.ProtoDoc;
+import org.infinispan.protostream.annotations.ProtoField;
+import org.infinispan.protostream.annotations.ProtoName;
+
+@ProtoDoc("@Indexed")
+@ProtoName("Model3")
+public class Model3C implements Model {
+
+    @ProtoField(number = 1)
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    public Integer entityVersion;
+
+    @ProtoField(number = 2)
+    public String id;
+
+    @ProtoField(number = 3)
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES, analyze = Analyze.YES, analyzer = @Analyzer(definition = \"lowercase\"))")
+    public String name;
+
+    @Override
+    public String getId() {
+        return id;
+    }
+}

--- a/index-evolution/src/main/java/fax/play/model3/Model3D.java
+++ b/index-evolution/src/main/java/fax/play/model3/Model3D.java
@@ -1,0 +1,31 @@
+package fax.play.model3;
+
+import fax.play.service.Model;
+import org.infinispan.protostream.annotations.ProtoDoc;
+import org.infinispan.protostream.annotations.ProtoField;
+import org.infinispan.protostream.annotations.ProtoName;
+
+@ProtoDoc("@Indexed")
+@ProtoName("Model3")
+public class Model3D implements Model {
+
+    @ProtoField(number = 1)
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    public Integer entityVersion;
+
+    @ProtoField(number = 2)
+    public String id;
+
+    @ProtoField(number = 3)
+    @Deprecated
+    public String name;
+
+    @ProtoField(number = 4)
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES, analyze = Analyze.YES, analyzer = @Analyzer(definition = \"lowercase\"))")
+    public String nameIndexed;
+
+    @Override
+    public String getId() {
+        return id;
+    }
+}

--- a/index-evolution/src/main/java/fax/play/model3/Model3E.java
+++ b/index-evolution/src/main/java/fax/play/model3/Model3E.java
@@ -1,0 +1,33 @@
+package fax.play.model3;
+
+import fax.play.service.Model;
+import org.infinispan.api.annotations.indexing.Keyword;
+import org.infinispan.protostream.annotations.ProtoDoc;
+import org.infinispan.protostream.annotations.ProtoField;
+import org.infinispan.protostream.annotations.ProtoName;
+
+@ProtoDoc("@Indexed")
+@ProtoName("Model3")
+public class Model3E implements Model {
+
+    @ProtoField(number = 1)
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    public Integer entityVersion;
+
+    @ProtoField(number = 2)
+    public String id;
+
+    @ProtoField(number = 3)
+    @Deprecated
+    public String name;
+
+    @ProtoField(number = 4)
+    //@ProtoDoc("@Field(index = Index.YES, store = Store.YES, analyze = Analyze.YES, analyzer = @Analyzer(definition = \"lowercase\"))")
+    @Keyword(sortable = true, normalizer = "lowercase")
+    public String newField;
+
+    @Override
+    public String getId() {
+        return id;
+    }
+}

--- a/index-evolution/src/main/java/fax/play/model3/Model3F.java
+++ b/index-evolution/src/main/java/fax/play/model3/Model3F.java
@@ -1,0 +1,27 @@
+package fax.play.model3;
+
+import fax.play.service.Model;
+import org.infinispan.protostream.annotations.ProtoDoc;
+import org.infinispan.protostream.annotations.ProtoField;
+import org.infinispan.protostream.annotations.ProtoName;
+
+@ProtoDoc("@Indexed")
+@ProtoName("Model3")
+public class Model3F implements Model {
+
+    @ProtoField(number = 1)
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    public Integer entityVersion;
+
+    @ProtoField(number = 2)
+    public String id;
+
+    @ProtoField(number = 4)
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES, analyze = Analyze.YES, analyzer = @Analyzer(definition = \"lowercase\"))")
+    public String nameIndexed;
+
+    @Override
+    public String getId() {
+        return id;
+    }
+}

--- a/index-evolution/src/main/java/fax/play/model3/Model3G.java
+++ b/index-evolution/src/main/java/fax/play/model3/Model3G.java
@@ -1,0 +1,32 @@
+package fax.play.model3;
+
+import fax.play.service.Model;
+import org.infinispan.protostream.annotations.ProtoDoc;
+import org.infinispan.protostream.annotations.ProtoField;
+import org.infinispan.protostream.annotations.ProtoName;
+
+@ProtoDoc("@Indexed")
+@ProtoName("Model3")
+public class Model3G implements Model {
+
+    @ProtoField(number = 1)
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    public Integer entityVersion;
+
+    @ProtoField(number = 2)
+    public String id;
+
+    @ProtoField(number = 3)
+    @Deprecated
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES, analyze = Analyze.YES, analyzer = @Analyzer(definition = \"lowercase\"))")
+    public String name;
+
+    @ProtoField(number = 4)
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    public String nameNonAnalyzed;
+
+    @Override
+    public String getId() {
+        return id;
+    }
+}

--- a/index-evolution/src/main/java/fax/play/model3/Model3H.java
+++ b/index-evolution/src/main/java/fax/play/model3/Model3H.java
@@ -1,0 +1,27 @@
+package fax.play.model3;
+
+import fax.play.service.Model;
+import org.infinispan.protostream.annotations.ProtoDoc;
+import org.infinispan.protostream.annotations.ProtoField;
+import org.infinispan.protostream.annotations.ProtoName;
+
+@ProtoDoc("@Indexed")
+@ProtoName("Model3")
+public class Model3H implements Model {
+
+    @ProtoField(number = 1)
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    public Integer entityVersion;
+
+    @ProtoField(number = 2)
+    public String id;
+
+    @ProtoField(number = 4)
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    public String nameNonAnalyzed;
+
+    @Override
+    public String getId() {
+        return id;
+    }
+}

--- a/index-evolution/src/main/java/fax/play/model3/Model3I.java
+++ b/index-evolution/src/main/java/fax/play/model3/Model3I.java
@@ -1,0 +1,31 @@
+package fax.play.model3;
+
+import fax.play.service.Model;
+import org.infinispan.protostream.annotations.ProtoDoc;
+import org.infinispan.protostream.annotations.ProtoField;
+import org.infinispan.protostream.annotations.ProtoName;
+
+@ProtoDoc("@Indexed")
+@ProtoName("Model3")
+public class Model3I implements Model {
+
+    @ProtoField(number = 1)
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    public Integer entityVersion;
+
+    @ProtoField(number = 2)
+    public String id;
+
+    @ProtoField(number = 3)
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES)")
+    public String name;
+
+    @ProtoField(number = 4)
+    @ProtoDoc("@Field(index = Index.YES, store = Store.YES, analyze = Analyze.YES, analyzer = @Analyzer(definition = \"lowercase\"))")
+    public String nameIndexed;
+
+    @Override
+    public String getId() {
+        return id;
+    }
+}

--- a/index-evolution/src/main/java/fax/play/model3/Schema3A.java
+++ b/index-evolution/src/main/java/fax/play/model3/Schema3A.java
@@ -1,0 +1,11 @@
+package fax.play.model3;
+
+import org.infinispan.protostream.GeneratedSchema;
+import org.infinispan.protostream.annotations.AutoProtoSchemaBuilder;
+
+@AutoProtoSchemaBuilder(includeClasses = Model3A.class, schemaFileName = "model3-schema.proto")
+public interface Schema3A extends GeneratedSchema {
+
+   Schema3A INSTANCE = new Schema3AImpl();
+
+}

--- a/index-evolution/src/main/java/fax/play/model3/Schema3B.java
+++ b/index-evolution/src/main/java/fax/play/model3/Schema3B.java
@@ -1,0 +1,11 @@
+package fax.play.model3;
+
+import org.infinispan.protostream.GeneratedSchema;
+import org.infinispan.protostream.annotations.AutoProtoSchemaBuilder;
+
+@AutoProtoSchemaBuilder(includeClasses = Model3B.class, schemaFileName = "model3-schema.proto")
+public interface Schema3B extends GeneratedSchema {
+
+   Schema3B INSTANCE = new Schema3BImpl();
+
+}

--- a/index-evolution/src/main/java/fax/play/model3/Schema3C.java
+++ b/index-evolution/src/main/java/fax/play/model3/Schema3C.java
@@ -1,0 +1,11 @@
+package fax.play.model3;
+
+import org.infinispan.protostream.GeneratedSchema;
+import org.infinispan.protostream.annotations.AutoProtoSchemaBuilder;
+
+@AutoProtoSchemaBuilder(includeClasses = Model3C.class, schemaFileName = "model3-schema.proto")
+public interface Schema3C extends GeneratedSchema {
+
+   Schema3C INSTANCE = new Schema3CImpl();
+
+}

--- a/index-evolution/src/main/java/fax/play/model3/Schema3D.java
+++ b/index-evolution/src/main/java/fax/play/model3/Schema3D.java
@@ -1,0 +1,11 @@
+package fax.play.model3;
+
+import org.infinispan.protostream.GeneratedSchema;
+import org.infinispan.protostream.annotations.AutoProtoSchemaBuilder;
+
+@AutoProtoSchemaBuilder(includeClasses = Model3D.class, schemaFileName = "model3-schema.proto")
+public interface Schema3D extends GeneratedSchema {
+
+   Schema3D INSTANCE = new Schema3DImpl();
+
+}

--- a/index-evolution/src/main/java/fax/play/model3/Schema3E.java
+++ b/index-evolution/src/main/java/fax/play/model3/Schema3E.java
@@ -1,0 +1,11 @@
+package fax.play.model3;
+
+import org.infinispan.protostream.GeneratedSchema;
+import org.infinispan.protostream.annotations.AutoProtoSchemaBuilder;
+
+@AutoProtoSchemaBuilder(includeClasses = Model3E.class, schemaFileName = "model3-schema.proto")
+public interface Schema3E extends GeneratedSchema {
+
+   Schema3E INSTANCE = new Schema3EImpl();
+
+}

--- a/index-evolution/src/main/java/fax/play/model3/Schema3F.java
+++ b/index-evolution/src/main/java/fax/play/model3/Schema3F.java
@@ -1,0 +1,11 @@
+package fax.play.model3;
+
+import org.infinispan.protostream.GeneratedSchema;
+import org.infinispan.protostream.annotations.AutoProtoSchemaBuilder;
+
+@AutoProtoSchemaBuilder(includeClasses = Model3F.class, schemaFileName = "model3-schema.proto")
+public interface Schema3F extends GeneratedSchema {
+
+   Schema3F INSTANCE = new Schema3FImpl();
+
+}

--- a/index-evolution/src/main/java/fax/play/model3/Schema3G.java
+++ b/index-evolution/src/main/java/fax/play/model3/Schema3G.java
@@ -1,0 +1,11 @@
+package fax.play.model3;
+
+import org.infinispan.protostream.GeneratedSchema;
+import org.infinispan.protostream.annotations.AutoProtoSchemaBuilder;
+
+@AutoProtoSchemaBuilder(includeClasses = Model3G.class, schemaFileName = "model3-schema.proto")
+public interface Schema3G extends GeneratedSchema {
+
+   Schema3G INSTANCE = new Schema3GImpl();
+
+}

--- a/index-evolution/src/main/java/fax/play/model3/Schema3H.java
+++ b/index-evolution/src/main/java/fax/play/model3/Schema3H.java
@@ -1,0 +1,11 @@
+package fax.play.model3;
+
+import org.infinispan.protostream.GeneratedSchema;
+import org.infinispan.protostream.annotations.AutoProtoSchemaBuilder;
+
+@AutoProtoSchemaBuilder(includeClasses = Model3H.class, schemaFileName = "model3-schema.proto")
+public interface Schema3H extends GeneratedSchema {
+
+   Schema3H INSTANCE = new Schema3HImpl();
+
+}

--- a/index-evolution/src/main/java/fax/play/model3/Schema3I.java
+++ b/index-evolution/src/main/java/fax/play/model3/Schema3I.java
@@ -1,0 +1,11 @@
+package fax.play.model3;
+
+import org.infinispan.protostream.GeneratedSchema;
+import org.infinispan.protostream.annotations.AutoProtoSchemaBuilder;
+
+@AutoProtoSchemaBuilder(includeClasses = Model3I.class, schemaFileName = "model3-schema.proto")
+public interface Schema3I extends GeneratedSchema {
+
+   Schema3I INSTANCE = new Schema3IImpl();
+
+}

--- a/index-evolution/src/main/java/fax/play/service/CacheProvider.java
+++ b/index-evolution/src/main/java/fax/play/service/CacheProvider.java
@@ -18,6 +18,10 @@ public class CacheProvider {
       return cacheManager;
    }
 
+   public RemoteCacheManager getCacheManager() {
+      return cacheManager;
+   }
+
    public RemoteCacheManager updateSchemaAndGet(CacheDefinition cacheDefinition, GeneratedSchema ... schemas) {
       stop();
       cacheManager = CacheFactory.create(cacheDefinition, schemas);
@@ -28,6 +32,18 @@ public class CacheProvider {
       stop();
       cacheManager = CacheFactory.create(null, schemas);
       return cacheManager;
+   }
+
+   public void updateIndexSchema(String ... cacheNames) {
+      for (String cacheName : cacheNames) {
+         cacheManager.administration().updateIndexSchema(cacheName);
+      }
+   }
+
+   public void reindexCaches(String ... cacheNames) {
+      for (String cacheName : cacheNames) {
+         cacheManager.administration().reindexCache(cacheName);
+      }
    }
 
    public void stop() {

--- a/index-evolution/src/main/java/fax/play/service/Model.java
+++ b/index-evolution/src/main/java/fax/play/service/Model.java
@@ -1,4 +1,7 @@
 package fax.play.service;
 
 public interface Model {
+    default String getId() {
+        return null;
+    }
 }

--- a/index-evolution/src/test/java/fax/play/smoke/BasicsForNoDowntimeUpgradesTest.java
+++ b/index-evolution/src/test/java/fax/play/smoke/BasicsForNoDowntimeUpgradesTest.java
@@ -1,0 +1,340 @@
+package fax.play.smoke;
+
+import fax.play.model3.Model3D;
+import fax.play.model3.Model3G;
+import fax.play.model3.Model3I;
+import fax.play.model3.Schema3A;
+import fax.play.model3.Schema3B;
+import fax.play.model3.Schema3C;
+import fax.play.model3.Schema3D;
+import fax.play.model3.Schema3E;
+import fax.play.model3.Schema3F;
+import fax.play.model3.Schema3G;
+import fax.play.model3.Schema3H;
+import fax.play.model3.Schema3I;
+import fax.play.service.CacheDefinition;
+import fax.play.service.CacheProvider;
+import fax.play.service.Model;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.Search;
+import org.infinispan.query.dsl.Query;
+import org.infinispan.query.dsl.QueryFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static fax.play.service.CacheProvider.CACHE1_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * This test class contains use-cases that are necessary in the first phase of Keycloak no-downtime store to work
+ *
+ * All of these use-cases are build with an assumption that any field that was or will be used in a query is indexed
+ * this means
+ *   - If we remove index, we stop using the field in queries or remove field
+ *   - If we add index we didn't use the field in any query, but now we want to
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class BasicsForNoDowntimeUpgradesTest {
+
+    private final CacheProvider cacheProvider = new CacheProvider();
+
+    /**
+     * This is used, for example, when a new feature is added
+     * the field has no meaning in the older version, so there is no migration needed
+     * once the new feature is used, the field is set including the index
+     */
+    @Test
+    void testAddNewFieldWithIndex() {
+         // VERSION 1
+        RemoteCache<String, Model> cache = cacheProvider
+                .init(new CacheDefinition(CACHE1_NAME, "Model3"), Schema3A.INSTANCE)
+                .getCache(CACHE1_NAME);
+
+        // Create first version entities
+        ModelUtils.createModel1Entities(cache, 5, ModelUtils.createModelA(1));
+
+        // Check there is only one with 3 in name field
+        doQuery("FROM Model3 WHERE name LIKE '%3%'", cache, 1);
+
+
+        // VERSION 2
+        cache = cacheProvider.updateSchemaAndGet(Schema3E.INSTANCE)
+                .getCache(CACHE1_NAME);
+
+        cacheProvider.updateIndexSchema(CACHE1_NAME);
+
+        // Create second version entities
+        ModelUtils.createModel1Entities(cache, 5, ModelUtils.createModelE(2));
+
+        // check there are all entities, new and old in the cache
+        assertThat(cache.size()).isEqualTo(10);
+
+        // Only new entities contain the new field, no old entity should be returned
+        doQuery("FROM Model3 WHERE newField LIKE '%3%'", cache, 1);
+
+        // Test lowercase normalizer
+        doQuery("FROM Model3 WHERE newField LIKE 'Cool%fiEld%3%' ORDER BY newField", cache, 1);
+    }
+
+    /**
+     * This example shows addition of an index on existing field that was NOT used in any query in the previous version
+     *
+     * This is used when we add some functionality that needs to search entities by field that existed before, but
+     * was not queried
+     *
+     * Currently, all fields, that are included in some query, are indexed
+     *
+     */
+    @Test
+    void testAddAIndexOnExistingFieldThatWasNotUsedInAnyQueryBefore() {
+        // VERSION 1
+        RemoteCache<String, Model> cache = cacheProvider
+                .init(new CacheDefinition(CACHE1_NAME, "Model3"), Schema3A.INSTANCE)
+                .getCache(CACHE1_NAME);
+
+        // Create VERSION 1 entities
+        ModelUtils.createModel1Entities(cache, 5, ModelUtils.createModelA(1));
+
+        // This is just for testing, the field is not used in any used query in VERSION 1
+        doQuery("FROM Model3 WHERE name LIKE '%3%'", cache, 1);
+
+        // VERSION 2 - note in this version we are NOT able to use the functionality that for the reason for adding index
+        // Update to second schema that adds nameIndexed field
+        CacheProvider cacheProviderV2 = new CacheProvider();
+        RemoteCache<String, Model> cacheV2 = cacheProviderV2.updateSchemaAndGet(Schema3D.INSTANCE)
+                .getCache(CACHE1_NAME);
+
+        // Index schema needs to be updated (this is done with no-downtime)
+        cacheProvider.updateIndexSchema(CACHE1_NAME);
+
+        // Create VERSION 2 entities
+        // Entities created in this version needs to have both name and nameIndexed fields so that VERSION 1 is able to read
+        // these entities
+        ModelUtils.createModel1Entities(cacheV2, 5, ModelUtils.createModelD(2));
+
+        // This is just to check data were created correctly, VERSION 2 doesn't use name nor nameIndexed in any query
+        // non-indexed field name should be set on both version new and old
+        doQuery("FROM Model3 WHERE name LIKE '%3%'", cacheV2, 2);
+        // indexed field nameIndexed should be present only in entities created by VERSION 2 as no reindexing was done yet
+        doQuery("FROM Model3 WHERE nameIndexed : '*3*'", cacheV2, 1);
+
+        // In this state we can ask administrator to perform update of all entities to VERSION 2 before migrating to VERSION 3
+        // The advantage of this approach is:
+        //     1. Keycloak is fully functional in the meanwhile
+        //     2. Migration can be postponed to any time the administrator wishes (e.g. midnight)
+        migrateEntityAToEntityD(cacheProviderV2.getCacheManager().getCache(CACHE1_NAME));
+
+        // VERSION 3 - note from this version we are able to use the functionality that was the reason for adding the index
+        // Update schema to version without name field
+        cache = cacheProvider.updateSchemaAndGet(Schema3F.INSTANCE)
+                .getCache(CACHE1_NAME);
+
+        // Create VERSION 3 entities, entity V3 can't contain name field because ModelF doesn't contain it
+        // in other words, migrating all entities to V3 removes name field from all entities
+        // The migration is not necessary though the presence of name field should not interfere normal Keycloak behaviour
+        ModelUtils.createModel1Entities(cache, 5, ModelUtils.createModelF(3));
+
+        // It is possible there is an older VERSION 2 node writing/reading to/from the cache, it should work
+        ModelUtils.createModel1Entities(cacheV2, 5, i -> ModelUtils.createModelD(2).apply(i + 10)); // Creating entities with ids +10 offset
+
+        // This is to check that older version is correctly writing also deprecated name field even though current
+        // schema present in the Infinispan server doesn't contain it
+        RemoteCache<String, Model3D> cacheV2Typed = cacheProviderV2.getCacheManager().getCache(CACHE1_NAME);
+        Model3D model3D = cacheV2Typed.get("300013");
+        assertThat(model3D.name).isEqualTo("modelD # 13");
+
+        // Query on nameIndexed should work with all entities >= 2 (e.g. all in the storage because we did the migration `migrateEntityAToEntityD`)
+        doQuery("FROM Model3 WHERE nameIndexed : '*3*'", cache, 4);
+    }
+
+    /**
+     * This example shows how an index can be removed
+     *
+     * In this example we assume the reason for removing the index is that it is no longer used in any query anymore
+     */
+    @Test
+    void testRemoveIndexWhenNoLongerUsedInQueryInNewerVersion() {
+        // VERSION 1
+        RemoteCache<String, Model> cache = cacheProvider
+                .init(new CacheDefinition(CACHE1_NAME, "Model3"), Schema3B.INSTANCE)
+                .getCache(CACHE1_NAME);
+
+        // Create VERSION 1 entities
+        ModelUtils.createModel1Entities(cache, 5, ModelUtils.createModelB(1));
+
+        // VERSION 1 uses name in a query
+        doQuery("FROM Model3 WHERE name LIKE '%3%'", cache, 1);
+
+        // VERSION 2
+        // In this version we cannot remove the index as node of VERSION 1 can still make a query with name in it
+        // The important part of this version is to remove all occurrences of the name field in queries
+        // Note: this version is needed only for analyzed fields, non-analyzed fields could work even without this,
+        // although currently we need it as well unless https://issues.redhat.com/browse/ISPN-8584 is resolved
+
+        // VERSION 3
+        // In this version we can be sure there is no query with name in it, therefore we can remove the index
+
+        // Update schema to not include index on name
+        // Note: If the reason for removal is removal of field completely, the process would be the same with the difference,
+        //  that this schema does not contain the field
+        cache = cacheProvider
+                .updateSchemaAndGet(Schema3A.INSTANCE)
+                .getCache(CACHE1_NAME);
+
+        // update index schema
+        cacheProvider.updateIndexSchema(CACHE1_NAME);
+
+        // Create entities without index
+        ModelUtils.createModel1Entities(cache, 5, ModelUtils.createModelA(2));
+
+        // Try query with field that has the index in both versions
+        doQuery("FROM Model3 WHERE entityVersion >= 1", cache, 10);
+        // TODO: Can we somehow cleanup indexed data only for name field?
+    }
+
+    @Test
+    void testMigrateAnalyzedFieldToNonAnalyzed() {
+        // VERSION 1
+        RemoteCache<String, Model> cache = cacheProvider
+                .init(new CacheDefinition(CACHE1_NAME, "Model3"), Schema3C.INSTANCE)
+                .getCache(CACHE1_NAME);
+
+        // Create VERSION 1 entities with analyzed index
+        ModelUtils.createModel1Entities(cache, 5, ModelUtils.createModelC(1));
+        doQuery("FROM Model3 WHERE name : '*3*'", cache, 1);
+
+        // Update schema to VERSION 2 that contains both analyzed and non-analyzed field
+        cache = cacheProvider
+                .updateSchemaAndGet(Schema3G.INSTANCE)
+                .getCache(CACHE1_NAME);
+
+        // update index schema
+        cacheProvider.updateIndexSchema(CACHE1_NAME);
+
+        // Create VERSION 2 entities with both indexes
+        ModelUtils.createModel1Entities(cache, 5, ModelUtils.createModelG(2));
+
+        // We need to do queries that are backward compatible
+        doQuery("FROM Model3 WHERE (entityVersion < 2 AND name : '*3*') OR (entityVersion >= 2 AND nameNonAnalyzed LIKE '%3%')", cache, 2);
+
+        // In this version we request administrator to migrate to VERSION 2 entities
+        migrateEntityDToEntityG(cacheProvider.getCacheManager().getCache(CACHE1_NAME));
+
+        // VERSION 3
+        // In this version we can stop using query that uses both old and new field because we know that all entities
+        //  in the storage are upgraded to VERSION 2
+        doQuery("FROM Model3 WHERE nameNonAnalyzed LIKE '%3%'", cache, 2);
+
+        // VERSION 4
+        // Now we can remove deprecated name field
+        cache = cacheProvider
+                .updateSchemaAndGet(Schema3H.INSTANCE)
+                .getCache(CACHE1_NAME);
+
+        ModelUtils.createModel1Entities(cache, 5, ModelUtils.createModelH(3));
+        doQuery("FROM Model3 WHERE nameNonAnalyzed LIKE '%3%'", cache, 3);
+    }
+
+    @Test
+    void testMigrateNonAnalyzedFieldToAnalyzed() {
+        // VERSION 1
+        RemoteCache<String, Model> cache = cacheProvider
+                .init(new CacheDefinition(CACHE1_NAME, "Model3"), Schema3B.INSTANCE)
+                .getCache(CACHE1_NAME);
+
+        // Create VERSION 1 entities with non-analyzed index
+        ModelUtils.createModel1Entities(cache, 5, ModelUtils.createModelB(1));
+        doQuery("FROM Model3 WHERE name LIKE '%3%'", cache, 1);
+
+        // Update schema to VERSION 2 that contains both non-analyzed and analyzed field
+        cache = cacheProvider
+                .updateSchemaAndGet(Schema3I.INSTANCE)
+                .getCache(CACHE1_NAME);
+
+        // update index schema
+        cacheProvider.updateIndexSchema(CACHE1_NAME);
+
+        // Create VERSION 2 entities with both indexes
+        ModelUtils.createModel1Entities(cache, 5, ModelUtils.createModelI(2));
+
+        // We need to do queries that are backward compatible
+        doQuery("FROM Model3 WHERE (entityVersion < 2 AND name LIKE '%3%') OR (entityVersion >= 2 AND nameIndexed : '*3*')", cache, 2);
+
+        // In this version we request administrator to migrate to VERSION 2 entities
+        migrateEntityBToEntityI(cacheProvider.getCacheManager().getCache(CACHE1_NAME));
+
+        // VERSION 3
+        // In this version we can stop using query that uses both old and new field because we know that all entities
+        //  in the storage are upgraded to VERSION 2
+        doQuery("FROM Model3 WHERE nameIndexed : '*3*'", cache, 2);
+
+        // VERSION 4
+        // Now we can remove deprecated name field
+        cache = cacheProvider
+                .updateSchemaAndGet(Schema3F.INSTANCE)
+                .getCache(CACHE1_NAME);
+
+        ModelUtils.createModel1Entities(cache, 5, ModelUtils.createModelF(3));
+        doQuery("FROM Model3 WHERE nameIndexed : '*3*'", cache, 3);
+    }
+
+    private <T> void doQuery(String query, RemoteCache<String, T> messageCache, int expectedResults) {
+        QueryFactory queryFactory = Search.getQueryFactory(messageCache);
+        Query<T> infinispanObjectEntities = queryFactory.create(query);
+        Set<T> result = StreamSupport.stream(infinispanObjectEntities.spliterator(), false)
+                .collect(Collectors.toSet());
+
+        assertThat(result).hasSize(expectedResults);
+    }
+
+    private void migrateEntityAToEntityD(final RemoteCache<String, Model3D> cache) {
+        new HashSet<>(cache.keySet())
+                .forEach(e -> {
+                    Model3D model3D = cache.get(e);
+                    if (model3D.entityVersion == 1) {
+                        model3D.nameIndexed = model3D.name;
+                        model3D.name = null;
+                        model3D.entityVersion = 2;
+                        cache.put(model3D.id, model3D);
+                    }
+                });
+    }
+
+    private void migrateEntityDToEntityG(final RemoteCache<String, Model3G> cache) {
+        new HashSet<>(cache.keySet())
+                .forEach(e -> {
+                    Model3G model3G = cache.get(e);
+                    if (model3G.entityVersion == 1) {
+                        model3G.nameNonAnalyzed = model3G.name;
+                        model3G.name = null;
+                        model3G.entityVersion = 2;
+                        cache.put(model3G.id, model3G);
+                    }
+                });
+    }
+
+    private void migrateEntityBToEntityI(final RemoteCache<String, Model3I> cache) {
+        new HashSet<>(cache.keySet())
+                .forEach(e -> {
+                    Model3I model3G = cache.get(e);
+                    if (model3G.entityVersion == 1) {
+                        model3G.nameIndexed = model3G.name;
+                        model3G.name = null;
+                        model3G.entityVersion = 2;
+                        cache.put(model3G.id, model3G);
+                    }
+                });
+    }
+
+    @AfterAll
+    public void afterAll() {
+        cacheProvider.stop();
+    }
+
+}

--- a/index-evolution/src/test/java/fax/play/smoke/MinorsForNoDowntimeUpgradesTest.java
+++ b/index-evolution/src/test/java/fax/play/smoke/MinorsForNoDowntimeUpgradesTest.java
@@ -1,0 +1,205 @@
+package fax.play.smoke;
+
+import fax.play.model3.Model3D;
+import fax.play.model3.Schema3A;
+import fax.play.model3.Schema3B;
+import fax.play.model3.Schema3D;
+import fax.play.model3.Schema3F;
+import fax.play.service.CacheDefinition;
+import fax.play.service.CacheProvider;
+import fax.play.service.Model;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.Search;
+import org.infinispan.query.dsl.Query;
+import org.infinispan.query.dsl.QueryFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static fax.play.service.CacheProvider.CACHE1_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * This test class contains use-cases that are not so probable to happe
+ * therefore I split them into separate test class
+ *
+ * The reason these are not so probable is that currently we added indexes for all field that are used in a query,
+ * but in the future we may break this rule and usecases in this class will become necessary.
+ *
+ * Some use-cases doesn't work due to: https://issues.redhat.com/browse/ISPN-8584
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class MinorsForNoDowntimeUpgradesTest {
+    private final CacheProvider cacheProvider = new CacheProvider();
+
+    /**
+     * This is the same usecase as {@link BasicsForNoDowntimeUpgradesTest#testAddAIndexOnExistingFieldThatWasNotUsedInAnyQueryBefore}
+     *
+     * The difference is, that it seems for non-analyzed fields it could be possible to do the migration in one step
+     * on the other hand, I am not sure whether this works correctly as currently I don't know how to check whether
+     * the query used the index or not
+     */
+    @Test
+    void testAddNonAnalyzedIndexOnExistingField() {
+        // VERSION 1
+        RemoteCache<String, Model> cache = cacheProvider
+                .init(new CacheDefinition(CACHE1_NAME, "Model3"), Schema3A.INSTANCE)
+                .getCache(CACHE1_NAME);
+
+        // Create VERSION 1 entities
+        ModelUtils.createModel1Entities(cache, 5, ModelUtils.createModelA(1));
+
+        // Check there is only one with 3 in name field (Query that doesn't use index)
+        doQuery("FROM Model3 WHERE name LIKE '%3%'", cache, 1);
+
+        cache = cacheProvider.updateSchemaAndGet(Schema3B.INSTANCE)
+                .getCache(CACHE1_NAME);
+
+        // TODO: No index schema update nor reindex needed, is it correct?
+        //  Can I somehow check whether Infinispan used the index or not?
+
+        // Create second version entities
+        ModelUtils.createModel1Entities(cache, 5, ModelUtils.createModelB(2));
+
+        // check there are two entities with 3 in name field
+        doQuery("FROM Model3 WHERE name LIKE '%3%'", cache, 2);
+    }
+
+    /**
+     * Effectively the same as {@link BasicsForNoDowntimeUpgradesTest#testAddAIndexOnExistingFieldThatWasNotUsedInAnyQueryBefore}
+     * but in this case we want to add index on a field that was previously used in a query
+     */
+    @Test
+    void testAnalyzedIndexAddedInMoreSteps() {
+        // VERSION 1
+        RemoteCache<String, Model> cache = cacheProvider
+                .init(new CacheDefinition(CACHE1_NAME, "Model3"), Schema3A.INSTANCE)
+                .getCache(CACHE1_NAME);
+
+        // Create VERSION 1 entities
+        ModelUtils.createModel1Entities(cache, 5, ModelUtils.createModelA(1));
+        doQuery("FROM Model3 WHERE name LIKE '%3%'", cache, 1);
+
+        // VERSION 2
+        // Note: this version needs to be backward compatible with the old version
+        // Update to second schema
+        cache = cacheProvider.updateSchemaAndGet(Schema3D.INSTANCE)
+                .getCache(CACHE1_NAME);
+
+        // Index schema needs to be updated
+        cacheProvider.updateIndexSchema(CACHE1_NAME);
+
+        // Create second version entities
+        ModelUtils.createModel1Entities(cache, 5, ModelUtils.createModelD(2));
+
+        // Make query that count with both older version and newer version
+        // TODO: This doesn't work: ISPN005003: Exception reported java.lang.IllegalStateException: Unexpected condition type (FullTextTermExpr): PROP(nameIndexed):'*3*'
+        //   this is already reported https://issues.redhat.com/browse/ISPN-8584
+        doQuery("FROM Model3 WHERE (entityVersion = 1 AND name LIKE '%3%') OR (entityVersion >= 2 AND nameIndexed : '*3*')", cache, 2);
+
+        // In this state the product works correctly, the older version is able to read because the newer stores both name and nameIndexed, the newer version
+        // is able to read both the older and newer entities because it uses both name and nameIndexed in the query
+
+        // At this moment we can request administrator to migrate all stored entities from version 1 to version 2
+        // The advantage of this approach is:
+        //     1. Keycloak is fully functional in the meanwhile
+        //     2. Migration can be postponed to any time the administrator wishes (e.g. midnight)
+        migrateEntityAToEntityD(cacheProvider.getCacheManager().getCache(CACHE1_NAME));
+
+        // VERSION 3
+        // Now we can stop doing backward compatible queries (we won't let administrator update to this version unless
+        // all entities are VERSION 3) and use just this:
+        doQuery("FROM Model3 WHERE nameIndexed : '*3*'", cache, 2);
+
+        // VERSION 4
+        // Now we can remove deprecated name field
+        cache = cacheProvider.updateSchemaAndGet(Schema3F.INSTANCE)
+                .getCache(CACHE1_NAME);
+
+        // Create VERSION 4 entities, entity V4 can't contain name field because ModelF doesn't contain it
+        // in other words, migrating all entities to V4 removes name field from all entities, but it is not necessary
+        // the presence of name field should not interfere normal Keycloak behaviour
+        ModelUtils.createModel1Entities(cache, 5, ModelUtils.createModelF(3));
+        doQuery("FROM Model3 WHERE nameIndexed : '*3*'", cache, 3);
+    }
+
+    /**
+     * In this case, we remove index but preserve usage of the field in queries
+     *
+     * Since the index is non-analyzed the old queries should be valid also in the newer version therefore it should be
+     * enough to just stop using the index.
+     */
+    @Test
+    void testRemoveNonAnalyzedIndex() {
+        RemoteCache<String, Model> cache = cacheProvider
+                .init(new CacheDefinition(CACHE1_NAME, "Model3"), Schema3B.INSTANCE)
+                .getCache(CACHE1_NAME);
+
+        // Create entities with index
+        ModelUtils.createModel1Entities(cache, 5, ModelUtils.createModelB(1));
+        doQuery("FROM Model3 WHERE name LIKE '%3%'", cache, 1);
+
+        // Update schema to not include index on name
+        cache = cacheProvider
+                .updateSchemaAndGet(Schema3A.INSTANCE)
+                .getCache(CACHE1_NAME);
+
+        // update index schema
+        cacheProvider.updateIndexSchema(CACHE1_NAME);
+
+        // Create entities without index
+        ModelUtils.createModel1Entities(cache, 5, ModelUtils.createModelA(2));
+
+        // Try query with field that has the index in both versions
+        doQuery("FROM Model3 WHERE entityVersion >= 1", cache, 10);
+
+        // Try query with name, it should not use index and should return both new and old entities
+        doQuery("FROM Model3 WHERE name LIKE '%3%'", cache, 2);
+        // TODO: ^ this doesn't work it seems it is using index even though new schema doesn't contain it
+    }
+
+    /**
+     * This is a little more complicated than ^ as older full-text queries are no longer applicable for newer version
+     * that drops analyzed index
+     *
+     * Just realized this is effectively the same as {@link BasicsForNoDowntimeUpgradesTest#testMigrateAnalyzedFieldToNonAnalyzed()}
+     */
+    @Test
+    void testRemoveAnalyzedIndex() {
+    }
+
+    private void migrateEntityAToEntityD(final RemoteCache<String, Model3D> cache) {
+        new HashSet<>(cache.keySet())
+                .forEach(e -> {
+                    Model3D model3D = cache.get(e);
+                    if (model3D.entityVersion == 1) {
+                        model3D.nameIndexed = model3D.name;
+                        model3D.entityVersion = 2;
+                        cache.put(model3D.id, model3D);
+                    }
+                });
+    }
+
+    private <T> void doQuery(String query, RemoteCache<String, T> messageCache, int expectedResults) {
+        QueryFactory queryFactory = Search.getQueryFactory(messageCache);
+        Query<T> infinispanObjectEntities = queryFactory.create(query);
+        Set<T> result = StreamSupport.stream(infinispanObjectEntities.spliterator(), false)
+                .collect(Collectors.toSet());
+
+        assertThat(result).hasSize(expectedResults);
+    }
+
+
+    @AfterAll
+    public void afterAll() {
+        cacheProvider.stop();
+    }
+
+
+
+}

--- a/index-evolution/src/test/java/fax/play/smoke/ModelUtils.java
+++ b/index-evolution/src/test/java/fax/play/smoke/ModelUtils.java
@@ -1,0 +1,130 @@
+package fax.play.smoke;
+
+import fax.play.model3.Model3A;
+import fax.play.model3.Model3B;
+import fax.play.model3.Model3C;
+import fax.play.model3.Model3D;
+import fax.play.model3.Model3E;
+import fax.play.model3.Model3F;
+import fax.play.model3.Model3G;
+import fax.play.model3.Model3H;
+import fax.play.model3.Model3I;
+import fax.play.service.Model;
+import org.infinispan.client.hotrod.RemoteCache;
+
+import java.util.function.Function;
+
+public class ModelUtils {
+
+    private static int ID_VERSION_OFFSET = 100000;
+
+    public static Function<Integer, Model> createModelA(int version) {
+        return i -> {
+            Model3A m = new Model3A();
+            m.entityVersion = version;
+            m.id = String.valueOf(i);
+            m.name = "modelA # " + i;
+
+            return m;
+        };
+    }
+
+    public static Function<Integer, Model> createModelB(int version) {
+        return i -> {
+            Model3B m = new Model3B();
+            m.entityVersion = version;
+            m.id = String.valueOf(ID_VERSION_OFFSET + i);
+            m.name = "modelB # " + i;
+
+            return m;
+        };
+    }
+
+    public static Function<Integer, Model> createModelC(int version) {
+        return i -> {
+            Model3C m = new Model3C();
+            m.entityVersion = version;
+            m.id = String.valueOf((2 * ID_VERSION_OFFSET) + i);
+            m.name = "modelC # " + i;
+
+            return m;
+        };
+    }
+
+    public static Function<Integer, Model> createModelD(int version) {
+        return i -> {
+            Model3D m = new Model3D();
+            m.entityVersion = version;
+            m.id = String.valueOf((3 * ID_VERSION_OFFSET) + i);
+            m.name = "modelD # " + i;
+            m.nameIndexed = "modelD # " + i;
+
+            return m;
+        };
+    }
+
+    public static Function<Integer, Model> createModelE(int version) {
+        return i -> {
+            Model3E m = new Model3E();
+            m.entityVersion = version;
+            m.id = String.valueOf((4 * ID_VERSION_OFFSET) + i);
+            m.name = "modelE # " + i;
+            m.newField = "cOoLNewField-" + i;
+
+            return m;
+        };
+    }
+
+    public static Function<Integer, Model> createModelF(int version) {
+        return i -> {
+            Model3F m = new Model3F();
+            m.entityVersion = version;
+            m.id = String.valueOf((5 * ID_VERSION_OFFSET) + i);
+            m.nameIndexed = "modelF # " + i;
+
+            return m;
+        };
+    }
+
+    public static Function<Integer, Model> createModelG(int version) {
+        return i -> {
+            Model3G m = new Model3G();
+            m.entityVersion = version;
+            m.id = String.valueOf((6 * ID_VERSION_OFFSET) + i);
+            m.name = "modelG # " + i;
+            m.nameNonAnalyzed = m.name;
+
+            return m;
+        };
+    }
+
+    public static Function<Integer, Model> createModelH(int version) {
+        return i -> {
+            Model3H m = new Model3H();
+            m.entityVersion = version;
+            m.id = String.valueOf((7 * ID_VERSION_OFFSET) + i);
+            m.nameNonAnalyzed = "modelH # " + i;
+
+            return m;
+        };
+    }
+
+    public static Function<Integer, Model> createModelI(int version) {
+        return i -> {
+            Model3I m = new Model3I();
+            m.entityVersion = version;
+            m.id = String.valueOf((7 * ID_VERSION_OFFSET) + i);
+            m.nameIndexed = "modelI # " + i;
+            m.name = "modelI # " + i;
+
+            return m;
+        };
+    }
+
+    public static void createModel1Entities(RemoteCache<String, Model> cache, int number, Function<Integer, Model> modelProducer) {
+        for (int i = 0; i < number; i++) {
+            Model m = modelProducer.apply(i);
+            cache.put(m.getId(), m);
+        }
+    }
+}


### PR DESCRIPTION
This PR contains use cases for a no-downtime way of upgrading the index schema.

Currently, it seems that with the addition of `udpateIndexSchema` method the most probable changes to the index scheme for Keycloak new storage can be done in no-downtime matter. These are present in [BasicsForNoDowntimeUpgradesTest.java](https://github.com/fax4ever/infinispan-play/compare/main...mhajas:main#diff-62449eee2a2025f279e86d5d12280d6f791c0d9fb0970cfa9a20863f04b8918a) file. I tried to add as many details as possible to the comments, but please let me know if something is unclear.

Another part of this PR contains use-cases that are not so probable to happen but would be great to have them working if we will need to use these. The only missing part I can see at the moment that is blocking these is https://issues.redhat.com/browse/ISPN-8584 

Note: There are some TODO: comments, this way I marked all places where I need some help.